### PR TITLE
Update project.json without any imports

### DIFF
--- a/src/Autofac.Extras.Moq/project.json
+++ b/src/Autofac.Extras.Moq/project.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "Autofac": "4.0.0-rc3-*",
-    "Moq": "4.6.25-alpha",
+    "Moq": "4.6.36-alpha",
     "Autofac": "4.0.0-rc3-*",
     "Microsoft.CodeAnalysis.FxCopAnalyzers": {
       "type": "build",
@@ -30,12 +30,7 @@
   "description": "Autofac extension for automocking and creation of mock objects in Moq.",
   "frameworks": {
     "net451": {},
-    "netstandard1.3": {
-      "dependencies": {
-        "System.Diagnostics.TraceSource": "4.0.0"
-      },
-      "imports": "dotnet5.6"
-    }
+    "netstandard1.3": {}
   },
   "packOptions": {
     "iconUrl": "https://cloud.githubusercontent.com/assets/1156571/13684110/16b8f152-e6bf-11e5-84ae-22c66c6d351a.png",

--- a/test/Autofac.Extras.Moq.Test/project.json
+++ b/test/Autofac.Extras.Moq.Test/project.json
@@ -23,10 +23,7 @@
           "type": "platform",
           "version": "1.0.0"
         }
-      },
-      "imports": [
-        "dotnet5.6"
-      ]
+      }
     }
   },
   "packOptions": {


### PR DESCRIPTION
Castle.Core beta001 has been released with pure NetCore support. Moq is
updated to alpha36 with latest Castle dep.
This commit updates the version in project.json and remove the need of
`imports` (aka a malicious cog which sometimes make package depend on
Mono PCL on Unix).