### PR TITLE
Fix DependencyResolutionException for Lazy<> and Owned<> in Core 2.0

### DIFF
--- a/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
+++ b/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using System.Reflection;
 using Autofac.Builder;
 using Autofac.Core;
+using Autofac.Features.OwnedInstances;
 using Moq;
 
 namespace Autofac.Extras.Moq
@@ -100,7 +101,25 @@ namespace Autofac.Extras.Moq
             return !_createdServiceTypes.Contains(typedService.ServiceType) &&
                    ServiceIsAbstractOrNonSealedOrInterface(typedService) &&
                    !IsIEnumerable(typedService) &&
-                   !IsIStartable(typedService);
+                   !IsIStartable(typedService) &&
+                   !IsLazy(typedService) &&
+                   !IsOwned(typedService);
+        }
+
+        private static bool IsLazy(IServiceWithType typedService)
+        {
+            // We handle most generics, but we don't handle Lazy because that has special
+            // meaning in Autofac
+            return typedService.ServiceType.GetTypeInfo().IsGenericType &&
+                   typedService.ServiceType.GetTypeInfo().GetGenericTypeDefinition() == typeof(Lazy<>);
+        }
+
+        private static bool IsOwned(IServiceWithType typedService)
+        {
+            // We handle most generics, but we don't handle Owned because that has special
+            // meaning in Autofac
+            return typedService.ServiceType.GetTypeInfo().IsGenericType &&
+                   typedService.ServiceType.GetTypeInfo().GetGenericTypeDefinition() == typeof(Owned<>);
         }
 
         private static bool IsIEnumerable(IServiceWithType typedService)

--- a/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Autofac.Core;
+using Autofac.Features.OwnedInstances;
 using Xunit;
 
 namespace Autofac.Extras.Moq.Test
@@ -83,6 +84,22 @@ namespace Autofac.Extras.Moq.Test
         public void RegistrationsForIEnumerable_IsNotHandled()
         {
             var registrations = GetRegistrations<IEnumerable<ITestInterface>>();
+
+            Assert.Empty(registrations);
+        }
+
+        [Fact]
+        public void RegistrationsForLazy_IsNotHandled()
+        {
+            var registrations = GetRegistrations<Lazy<ITestInterface>>();
+
+            Assert.Empty(registrations);
+        }
+
+        [Fact]
+        public void RegistrationsForOwned_IsNotHandled()
+        {
+            var registrations = GetRegistrations<Owned<ITestInterface>>();
 
             Assert.Empty(registrations);
         }


### PR DESCRIPTION
This PR adds `Lazy<>` and `Owned<>` to the ignore list of `MoqRegistrationHandler` because these classes seem to have special meaning to Autofac. This seems to satisfy the test case I mentioned in #10.

There are a lot more changes I haven't pushed - in order to work on this, I had to upgrade the solution to VS 2017 and Core 2.0 SDK (which would totally break the current CI). Hopefully, these should not be required for resolving the issue.

Fixes #10 
