### PR TITLE
Fix dependency resolution for Meta<>

### DIFF
--- a/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
+++ b/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using System.Reflection;
 using Autofac.Builder;
 using Autofac.Core;
+using Autofac.Features.Metadata;
 using Autofac.Features.OwnedInstances;
 using Moq;
 
@@ -128,7 +129,8 @@ namespace Autofac.Extras.Moq
                    !IsIEnumerable(typedService) &&
                    !IsIStartable(typedService) &&
                    !IsLazy(typedService) &&
-                   !IsOwned(typedService);
+                   !IsOwned(typedService) &&
+                   !IsMeta(typedService);
         }
 
         private static bool IsLazy(IServiceWithType typedService)
@@ -146,6 +148,14 @@ namespace Autofac.Extras.Moq
             // meaning in Autofac
             var typeInfo = typedService.ServiceType.GetTypeInfo();
             return typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Owned<>);
+        }
+
+        private static bool IsMeta(IServiceWithType typedService)
+        {
+            // We handle most generics, but we don't handle Meta because that has special
+            // meaning in Autofac
+            var typeInfo = typedService.ServiceType.GetTypeInfo();
+            return typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Meta<>);
         }
 
         /// <summary>

--- a/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Autofac.Core;
+using Autofac.Features.Metadata;
 using Autofac.Features.OwnedInstances;
 using Xunit;
 
@@ -116,6 +117,14 @@ namespace Autofac.Extras.Moq.Test
         public void RegistrationsForOwned_IsNotHandled()
         {
             var registrations = GetRegistrations<Owned<ITestInterface>>();
+
+            Assert.Empty(registrations);
+        }
+
+        [Fact]
+        public void RegistrationsForMeta_IsNotHandled()
+        {
+            var registrations = GetRegistrations<Meta<ITestInterface>>();
 
             Assert.Empty(registrations);
         }


### PR DESCRIPTION
AutoMock would try to resolve Autofac's Meta<> wrapper, which would fail.  Based on how Lazy<> and Owned<> are handled, this fix seemed appropriate.