### PR TITLE
Don't add mock to IEnumerable resolution if service is already registered

### DIFF
--- a/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Autofac.Builder;
 using Autofac.Core;
 using Autofac.Features.OwnedInstances;
 using Xunit;
@@ -116,6 +117,20 @@ namespace Autofac.Extras.Moq.Test
         public void RegistrationsForOwned_IsNotHandled()
         {
             var registrations = GetRegistrations<Owned<ITestInterface>>();
+
+            Assert.Empty(registrations);
+        }
+
+        [Fact]
+        public void RegistrationsForAlreadyRegisteredCollection_IsNotHandled()
+        {
+            this._systemUnderTest.RegistrationsFor(
+                new TypedService(typeof(IEnumerable<ITestInterface>)),
+                null);
+
+            var registrations = this._systemUnderTest.RegistrationsFor(
+                new TypedService(typeof(ITestInterface)),
+                x => new[] { RegistrationBuilder.ForType<ITestInterface>().CreateRegistration() });
 
             Assert.Empty(registrations);
         }


### PR DESCRIPTION
I want to merge an existing autofac container into AutoMock and it works with one problem.  When resolving IEnumerable<IFoo>, I'll get the list of IFoo implementations that are registered in Autofac along with an extra Mock<IFoo>.  This causes tests to break because the Mock<IFoo> doesn't behave as expected.

I realize that this this is an edge case, but my fix does not break any tests.