### PR TITLE
Resolve #25 Do not add mock to IEnumerable<TService> if a type for TS…

### DIFF
--- a/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
+++ b/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
@@ -91,7 +91,9 @@ namespace Autofac.Extras.Moq
             }
 
             var typedService = service as TypedService;
-            if (typedService == null || !this.CanMockService(typedService))
+            if (typedService == null ||
+                registrationAccessor(service).Any() ||
+                !this.CanMockService(typedService))
             {
                 return Enumerable.Empty<IComponentRegistration>();
             }

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -1,5 +1,5 @@
-using System;
 using Moq;
+using System;
 using Xunit;
 
 namespace Autofac.Extras.Moq.Test
@@ -162,9 +162,7 @@ namespace Autofac.Extras.Moq.Test
             using (var mock = AutoMock.GetLoose())
             {
                 var component = mock.Create<TestComponentRequiringClassA>();
-                Assert.Equal(
-                    mock.Mock<ClassA>().Object,
-                    component.InstanceOfClassA);
+                Assert.NotNull(component.InstanceOfClassA);
             }
         }
 


### PR DESCRIPTION
Please check the test in the AutoMockFixture class.
After my change, the Mock method throws an InvalidCastException for ClassA.
I am not sure about the desired behavior.
I think the AnyConcreteTypeNotAlreadyRegisteredSource provides a class for ClassA since it has no dependencies. In my opinion, this test does not describe a real-world scenario.