### PR TITLE
Stop using ACTNAR to provide explicitly created or un-mockable types, do it all in moq source

### DIFF
--- a/src/Autofac.Extras.Moq/AutoMock.cs
+++ b/src/Autofac.Extras.Moq/AutoMock.cs
@@ -58,9 +58,10 @@ namespace Autofac.Extras.Moq
             // and Moq being last in are least likely to cause ordering conflicts.
             beforeBuild?.Invoke(builder);
 
-            builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
             builder.RegisterSource(new MoqRegistrationHandler(_createdServiceTypes));
+
             this.Container = builder.Build();
+
             this.VerifyAll = false;
         }
 

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Moq;
 using Xunit;
 
@@ -232,6 +234,61 @@ namespace Autofac.Extras.Moq.Test
                         SetUpSetupations(mock);
                     }
                 });
+        }
+
+        [Fact]
+        public void LooseCreate_SuccessfulOnUnregisteredGeneric()
+        {
+            var mock = AutoMock.GetLoose();
+            Assert.NotNull(mock.Create<GenericClassA<ClassA>>());
+        }
+
+        [Fact]
+        public void MockNotAddedToEnumerableIfTypeIsRegistered()
+        {
+            var autoMock = AutoMock.GetLoose(c =>
+            {
+                c.RegisterType<TestA>().As<ITest>();
+                c.RegisterType<TestB>().As<ITest>();
+
+                c.RegisterType<TestClassConsumesIEnumerable>();
+            });
+
+            var wrapper = autoMock.Create<TestClassConsumesIEnumerable>();
+
+            Assert.Equal(2, wrapper.All.Count());
+        }
+
+        public interface ITest
+        {
+        }
+
+        public class TestA : ITest
+        {
+        }
+
+        public class TestB : ITest
+        {
+        }
+
+        public class TestClassConsumesIEnumerable
+        {
+            public IEnumerable<ITest> All { get; }
+
+            public TestClassConsumesIEnumerable(IEnumerable<ITest> all)
+            {
+                All = all;
+            }
+        }
+
+        public class GenericClassA<T>
+        {
+            private readonly ClassA _dependency;
+
+            public GenericClassA(ClassA dependency)
+            {
+                _dependency = dependency;
+            }
         }
 
         private static void AssertProperties(AutoMock mock)

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -259,6 +259,16 @@ namespace Autofac.Extras.Moq.Test
             Assert.Equal(2, wrapper.All.Count());
         }
 
+        [Fact]
+        public void MockAddedToEnumerableIfNoTypeIsRegistered()
+        {
+            var autoMock = AutoMock.GetLoose();
+
+            var wrapper = autoMock.Create<TestClassConsumesIEnumerable>();
+
+            Assert.Single(wrapper.All);
+        }
+
         public interface ITest
         {
         }

--- a/test/Autofac.Extras.Moq.Test/Autofac.Extras.Moq.Test.csproj
+++ b/test/Autofac.Extras.Moq.Test/Autofac.Extras.Moq.Test.csproj
@@ -8,6 +8,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In order to no longer resolve IEnumerables that include Mocks (if you've already registered something), I had to remove the ACTNAR source and do it directly in the ``MoqRegistrationHandler``.

It is a fairly big internal change, but the external behaviour shouldn't have changed much.

Fixes #25 