### PR TITLE
Ensure we apply the same filters as ACTNARS

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.0.0.{build}
+version: 5.0.1.{build}
 
 configuration: Release
 

--- a/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
+++ b/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Autofac extension for automocking and creation of mock objects in Moq.</Description>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
+++ b/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
@@ -114,13 +114,17 @@ namespace Autofac.Extras.Moq
                                              .InstancePerLifetimeScope()
                                              .CreateRegistration();
                 }
-                else
+                else if (ServiceCompatibleWithAutomaticDirectRegistration(typedService))
                 {
                     // Issue #15 - Incompatible mocks need to be registered using the type.
                     // Their constructor dependencies will then be mocked.
                     result = RegistrationBuilder.ForType(typedService.ServiceType)
                                             .InstancePerLifetimeScope()
                                             .CreateRegistration();
+                }
+                else
+                {
+                    result = null;
                 }
             }
             else
@@ -152,6 +156,17 @@ namespace Autofac.Extras.Moq
         private static bool IsInsideAutofac(IServiceWithType typedService)
         {
             return typeof(IRegistrationSource).Assembly == typedService.ServiceType.Assembly;
+        }
+
+        private static bool ServiceCompatibleWithAutomaticDirectRegistration(IServiceWithType typedService)
+        {
+            var serviceType = typedService.ServiceType;
+
+            return serviceType.IsClass &&
+                   serviceType != typeof(string) &&
+                   !serviceType.IsSubclassOf(typeof(Delegate)) &&
+                   !serviceType.IsAbstract &&
+                   !serviceType.IsGenericTypeDefinition;
         }
 
         private static bool ServiceCompatibleWithMockRepositoryCreate(IServiceWithType typedService)

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -269,6 +269,32 @@ namespace Autofac.Extras.Moq.Test
             Assert.Single(wrapper.All);
         }
 
+        [Fact]
+        public void CreateClassWithParameter()
+        {
+            using (AutoMock autoMock = AutoMock.GetStrict())
+            {
+                var obj = autoMock.Create<ClassWithParameters>(new NamedParameter("param1", 10));
+                Assert.NotNull(obj);
+                Assert.True(obj.InvokedSimpleConstructor);
+            }
+        }
+
+        public class ClassWithParameters
+        {
+            public bool InvokedSimpleConstructor { get; }
+
+            public ClassWithParameters(int param1)
+                : this(param1, TimeSpan.Zero)
+            {
+                InvokedSimpleConstructor = true;
+            }
+
+            public ClassWithParameters(int param1, TimeSpan param2)
+            {
+            }
+        }
+
         public interface ITest
         {
         }

--- a/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
@@ -65,6 +65,22 @@ namespace Autofac.Extras.Moq.Test
         }
 
         [Fact]
+        public void RegistrationForNonClass_IsNotHandled()
+        {
+            var registrations = GetRegistrations<int>();
+
+            Assert.Empty(registrations);
+        }
+
+        [Fact]
+        public void RegistrationForString_IsNotHandled()
+        {
+            var registrations = GetRegistrations<string>();
+
+            Assert.Empty(registrations);
+        }
+
+        [Fact]
         public void RegistrationForSealedConcreteClass_IsHandled()
         {
             var registrations = GetRegistrations<TestSealedConcreteClass>();


### PR DESCRIPTION
Fixes #31.

Need to exclude the same types as ACTNARS from those we attempt to register ourselves.

Before these changes, the TimeSpan type would get registered as a service and would fail resolving a constructor on that type.