### PR TITLE
Explicitly state that mock has been requested

### DIFF
--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Autofac.Core;
 using Moq;
 using Xunit;
 
@@ -278,6 +279,38 @@ namespace Autofac.Extras.Moq.Test
                 Assert.NotNull(obj);
                 Assert.True(obj.InvokedSimpleConstructor);
             }
+        }
+
+        [Fact]
+        public void MockedClassWithConstructorThrows()
+        {
+            using (var mock = AutoMock.GetLoose())
+            {
+                mock.Mock<IDependency>().Setup(s => s.DoSomethingExternal()).Returns(7);
+                Assert.Throws<DependencyResolutionException>(() => mock.Mock<ClassWithDependency>());
+            }
+        }
+
+        public class ClassWithDependency
+        {
+            private readonly IDependency _dependency;
+
+            public ClassWithDependency(IDependency dependency)
+            {
+                _dependency = dependency;
+            }
+
+            public int DoSomeThing() => 0;
+        }
+
+        public class Dependency : IDependency
+        {
+            public int DoSomethingExternal() => 0;
+        }
+
+        public interface IDependency
+        {
+            int DoSomethingExternal();
         }
 
         public class ClassWithParameters

--- a/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
@@ -16,7 +16,7 @@ namespace Autofac.Extras.Moq.Test
 
         public MoqRegistrationHandlerFixture()
         {
-            this._systemUnderTest = new MoqRegistrationHandler(new List<Type>());
+            this._systemUnderTest = new MoqRegistrationHandler(new HashSet<Type>(), new HashSet<Type>());
         }
 
         private interface ISomethingStartable : IStartable
@@ -42,8 +42,8 @@ namespace Autofac.Extras.Moq.Test
         [Fact]
         public void RegistrationForCreatedType_IsHandled()
         {
-            var createdServiceTypes = new List<Type> { typeof(TestConcreteClass) };
-            var handler = new MoqRegistrationHandler(createdServiceTypes);
+            var createdServiceTypes = new HashSet<Type> { typeof(TestConcreteClass) };
+            var handler = new MoqRegistrationHandler(createdServiceTypes, new HashSet<Type>());
             var registrations = handler.RegistrationsFor(new TypedService(typeof(TestConcreteClass)), s => Enumerable.Empty<IComponentRegistration>());
 
             Assert.NotEmpty(registrations);


### PR DESCRIPTION
Objects that cannot be mocked now throw the right exception.

Fixes #33 