### PR TITLE
Registration of mocks through AutoMock are marked as externally owned…

### DIFF
--- a/src/Autofac.Extras.Moq/MockRegistrationExtensions.cs
+++ b/src/Autofac.Extras.Moq/MockRegistrationExtensions.cs
@@ -48,7 +48,7 @@ namespace Autofac.Extras.Moq
                 throw new System.ArgumentNullException(nameof(mock));
             }
 
-            return builder.RegisterInstance(mock.Object).As<TMocked>();
+            return builder.RegisterInstance(mock.Object).As<TMocked>().ExternallyOwned();
         }
     }
 }

--- a/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
+++ b/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
@@ -127,7 +127,6 @@ namespace Autofac.Extras.Moq
                     // Their constructor dependencies will then be mocked.
                     result = RegistrationBuilder.ForType(typedService.ServiceType)
                                             .InstancePerLifetimeScope()
-                                            .ExternallyOwned()
                                             .CreateRegistration();
                 }
                 else

--- a/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
+++ b/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
@@ -118,6 +118,7 @@ namespace Autofac.Extras.Moq
                     result = RegistrationBuilder.ForDelegate((c, p) => this.CreateMock(c, typedService))
                                              .As(service)
                                              .InstancePerLifetimeScope()
+                                             .ExternallyOwned()
                                              .CreateRegistration();
                 }
                 else if (ServiceCompatibleWithAutomaticDirectRegistration(typedService))
@@ -126,6 +127,7 @@ namespace Autofac.Extras.Moq
                     // Their constructor dependencies will then be mocked.
                     result = RegistrationBuilder.ForType(typedService.ServiceType)
                                             .InstancePerLifetimeScope()
+                                            .ExternallyOwned()
                                             .CreateRegistration();
                 }
                 else

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -124,6 +124,20 @@ namespace Autofac.Extras.Moq.Test
         }
 
         [Fact]
+        public void DisposableDoesNotThrowWhenContainerIsDisposedWhenRegisteredManually()
+        {
+            var mock = new Mock<IDisposable>(MockBehavior.Strict);
+            using (var automock = AutoMock.GetStrict(cfg => cfg.RegisterMock(mock)))
+            {
+                var sut = automock.Create<ConsumesDisposable>();
+
+                // no throw.
+            }
+        }
+
+
+
+        [Fact]
         public void GetFromRepositoryUsesLooseBehaviorSetOnRepository()
         {
             using (var mock = AutoMock.GetFromRepository(new MockRepository(MockBehavior.Loose)))

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -89,6 +89,41 @@ namespace Autofac.Extras.Moq.Test
         }
 
         [Fact]
+        public void DisposableDoesntThrowIfNotSetupInStrictMocking()
+        {
+            using (var mock = AutoMock.GetStrict())
+            {
+                // No setup for strict mock on IDisposable
+                // Should not throw on dispose of AutoMock.
+                var sut = mock.Create<ConsumesDisposable>();
+            }
+        }
+
+        [Fact]
+        public void DisposableDoesThrowIfNotSetupAndDisposedBySutInStrictMocking()
+        {
+            using (var mock = AutoMock.GetStrict())
+            {
+                var sut = mock.Create<DisposesDisposable>();
+
+                Assert.Throws<MockException>(() => sut.DisposeDependency());
+            }
+        }
+
+        [Fact]
+        public void DisposableDoesNotThrowIfSetupAndDisposedBySutInStrictMocking()
+        {
+            using (var mock = AutoMock.GetStrict())
+            {
+                mock.Mock<IInheritFromDisposable>().Setup(x => x.Dispose());
+                var sut = mock.Create<DisposesDisposable>();
+
+                // No throw
+                sut.DisposeDependency();
+            }
+        }
+
+        [Fact]
         public void GetFromRepositoryUsesLooseBehaviorSetOnRepository()
         {
             using (var mock = AutoMock.GetFromRepository(new MockRepository(MockBehavior.Loose)))
@@ -419,6 +454,20 @@ namespace Autofac.Extras.Moq.Test
             public ConsumesDisposable(IInheritFromDisposable disposable)
             {
                 this._disposable = disposable;
+            }
+        }
+
+        public class DisposesDisposable {
+            private IInheritFromDisposable _disposable;
+
+            public DisposesDisposable(IInheritFromDisposable disposable)
+            {
+                this._disposable = disposable;
+            }
+
+            public void DisposeDependency()
+            {
+                this._disposable.Dispose();
             }
         }
 


### PR DESCRIPTION
…, so that AutoMock doesn't try to dispose them when the container is disposing. This to prevent strict mocks from failing after the test is completed.

Based on issue: #35 

Questions:

- [x] Is there a substantial difference between the registrations in line 118 and 128 of `MoqRegistrationHandler.cs` that would warrant additional tests?
- [x] Would it make sense to make the same changes to `RegisterMock`? I noticed there were few tests covering that, so I left it alone for now.
- [ ] Are any changes to documentation needed for this?