### PR TITLE
Non generic create 

### DIFF
--- a/src/Autofac.Extras.Moq/AutoMock.cs
+++ b/src/Autofac.Extras.Moq/AutoMock.cs
@@ -178,7 +178,7 @@ namespace Autofac.Extras.Moq
         /// <summary>
         /// Resolve the specified type in the container (register it if needed).
         /// </summary>
-        /// <param name="serviceType">type of service</param>
+        /// <param name="serviceType">Type of service.</param>
         /// <param name="parameters">Optional parameters.</param>
         /// <returns>The service.</returns>
         public object Create(Type serviceType, params Parameter[] parameters)
@@ -208,7 +208,7 @@ namespace Autofac.Extras.Moq
             return obj.Mock;
         }
 
-        private object Create(bool isMock, Type serviceType, params Parameter[] parameters) 
+        private object Create(bool isMock, Type serviceType, params Parameter[] parameters)
         {
             if (isMock)
             {

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -355,7 +355,7 @@ namespace Autofac.Extras.Moq.Test
         [Fact]
         public void CreateNonGenericSameAsCreateGeneric() 
         {
-            using(var mock = AutoMock.GetLoose())
+            using (var mock = AutoMock.GetLoose())
             {
                 var generic = mock.Create<ServiceA>();
                 var nonGeneric = mock.Create(typeof(ServiceA));


### PR DESCRIPTION
Working on being able to switch the instance that gets created based on the type and wasn't able to do that with the provided generic method.

Aligns with the underlying `Autofac.ResolutionExtensions.Resolve`