### PR TITLE
7.0.0 - Update dependencies, update frameworks, add request for owner.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,9 @@
 {
   "recommendations": [
+    "bierner.markdown-emoji",
     "davidanson.vscode-markdownlint",
     "editorconfig.editorconfig",
-    "formulahendry.dotnet-test-explorer",
+    "gruntfuggly.todo-tree",
     "ms-dotnettools.csharp",
     "ryanluker.vscode-coverage-gutters",
     "stkb.rewrap",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,8 +12,29 @@
     "typeparam",
     "xunit"
   ],
-  "dotnet-test-explorer.testProjectPath": "test/**/*Test.csproj",
+  "coverage-gutters.coverageBaseDir": "artifacts/coverage",
+  "coverage-gutters.coverageFileNames": [
+    "coverage.net6.0.info"
+  ],
+  "dotnet-test-explorer.runInParallel": true,
+  "dotnet-test-explorer.testProjectPath": "test/**/*.Test.csproj",
   "dotnet.defaultSolution": "Autofac.Extras.Moq.sln",
-  "omnisharp.enableEditorConfigSupport": true,
-  "omnisharp.enableRoslynAnalyzers": true
+  "dotnet.preferRuntimeFromSDK": true,
+  "dotnet.unitTestDebuggingOptions": {
+    "enableStepFiltering": false,
+    "justMyCode": false,
+    "requireExactSource": false,
+    "sourceLinkOptions": {
+      "*": {
+        "enabled": true
+      }
+    },
+    "suppressJITOptimizations": true,
+    "symbolOptions": {
+      "searchNuGetOrgSymbolServer": true
+    }
+  },
+  "files.watcherExclude": {
+    "**/target": true
+  }
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Please file issues and pull requests for this package in this repository rather 
 - [Documentation](https://autofac.readthedocs.io/en/latest/integration/moq.html)
 - [NuGet](https://www.nuget.org/packages/Autofac.Extras.Moq)
 - [Contributing](https://autofac.readthedocs.io/en/latest/contributors.html)
+- [Open in Visual Studio Code](https://open.vscode.dev/autofac/Autofac.Extras.Moq)
+
+> :warning: **LOOKING FOR AN OWNER!** This package is largely in maintenance mode - if you'd like to help the community out and pull it out of maintenance mode, [come drop us a line!](https://github.com/autofac/Autofac.Extras.Moq/issues/50)
 
 ## Quick Start
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Ubuntu
 
-version: 6.1.1.{build}
+version: 7.0.0.{build}
 
 dotnet_csproj:
-  version_prefix: '6.1.1'
+  version_prefix: '7.0.0'
   patch: true
   file: 'src\**\*.csproj'
 

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -14,6 +14,8 @@
     <Rule Id="CA1822" Action="None" />
     <!-- Seal internal types - tests use internal types for stubs and performance isn't a problem; this causes unnecessary ceremony. -->
     <Rule Id="CA1852" Action="None" />
+    <!-- Call ConfigureAwait - conflicts with xUnit1030 and may cause test parallelization limits to be bypassed. -->
+    <Rule Id="CA2007" Action="None" />
     <!-- Implement serialization constructors - false positive when building .NET Core -->
     <Rule Id="CA2229" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "6.0.412",
+    "version": "8.0.401",
     "rollForward": "latestFeature"
   },
 
   "additionalSdks": [
-    "5.0.408"
+    "6.0.425"
   ]
 }

--- a/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
+++ b/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
@@ -61,15 +61,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Autofac" Version="8.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Moq" Version="4.7.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/test/Autofac.Extras.Moq.Test/Autofac.Extras.Moq.Test.csproj
+++ b/test/Autofac.Extras.Moq.Test/Autofac.Extras.Moq.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -35,20 +35,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/MoqRegistrationHandlerFixture.cs
@@ -35,8 +35,8 @@ public class MoqRegistrationHandlerFixture
 
         Assert.NotEmpty(registrations);
 
-        createdServiceTypes.Add(typeof(TestAbstractClass));
-        registrations = handler.RegistrationsFor(new TypedService(typeof(TestAbstractClass)), s => Enumerable.Empty<ServiceRegistration>());
+        createdServiceTypes.Add(typeof(TestImplementationOneB));
+        registrations = handler.RegistrationsFor(new TypedService(typeof(TestImplementationOneB)), s => Enumerable.Empty<ServiceRegistration>());
 
         Assert.NotEmpty(registrations);
     }


### PR DESCRIPTION
- Breaking changes:
  - Add .NET 8 support, drop .NET 5 support.
  - Update minimum Autofac to 8.1.0.
- Other changes:
  - Update all dependencies as possible. Includes update to Moq 4.18.4.
  - Update nullable type annotations.
  - Fix invalid test that incorrectly registered an abstract class.