### PR TITLE
Technology refresh: update dependencies and target frameworks

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
-    <Version>7.0.0</Version>
+    <Version>8.0.0</Version>
     <SolutionName>Autofac.Extras.Moq</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
+++ b/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
@@ -12,7 +12,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
@@ -59,14 +59,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="8.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Autofac" Version="9.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Updated package version from 7.0.0 to 8.0.0
- Added net10.0 to target frameworks (replacing net6.0)
- Updated Autofac dependency from 8.1.0 to 9.1.0
- Updated Microsoft.SourceLink.GitHub from 8.0.0 to 10.0.300
- Removed unnecessary System.ComponentModel.TypeConverter package reference (NU1510 warning)
- Kept Moq at 4.18.4 (last version before SponsorLink controversy)

## Test plan
- [x] Build succeeds with zero errors
- [x] All 48 tests pass on net10.0