### PR TITLE
Forward constructor parameters when mocking a type (#42)

### DIFF
--- a/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
+++ b/src/Autofac.Extras.Moq/MoqRegistrationHandler.cs
@@ -28,6 +28,14 @@ internal class MoqRegistrationHandler : IRegistrationSource
     private readonly MethodInfo _createMethod = typeof(MockRepository).GetMethod(nameof(MockRepository.Create), Array.Empty<Type>()) ?? throw new NotSupportedException("Unable to bind to Create method.");
 
     /// <summary>
+    /// This is <see cref="MockFactory.Create{T}(object[])"/> which forwards
+    /// constructor arguments to the mocked type. It is used when the caller
+    /// supplies parameters (issue #42) so abstract/class mocks can be created
+    /// using a constructor that takes arguments.
+    /// </summary>
+    private readonly MethodInfo _createWithArgsMethod = typeof(MockRepository).GetMethod(nameof(MockRepository.Create), new[] { typeof(object[]) }) ?? throw new NotSupportedException("Unable to bind to Create method with constructor arguments.");
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MoqRegistrationHandler"/> class.
     /// </summary>
     /// <param name="createdServiceTypes">A set of root services that have been created.</param>
@@ -90,7 +98,7 @@ internal class MoqRegistrationHandler : IRegistrationSource
             // This will ensure mocking exceptions get properly thrown.
             if (_mockedServiceTypes.Contains(typedService.ServiceType) || ServiceCompatibleWithMockRepositoryCreate(typedService))
             {
-                result = RegistrationBuilder.ForDelegate((c, p) => CreateMock(c, typedService))
+                result = RegistrationBuilder.ForDelegate((c, p) => CreateMock(c, typedService, p))
                                          .As(service)
                                          .SingleInstance()
                                          .ExternallyOwned()
@@ -198,6 +206,98 @@ internal class MoqRegistrationHandler : IRegistrationSource
         return typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Meta<>);
     }
 
+    /// <summary>
+    /// Maps the supplied Autofac parameters onto the constructor arguments of
+    /// the type being mocked. Supports <see cref="TypedParameter"/>,
+    /// <see cref="NamedParameter"/> and <see cref="PositionalParameter"/> (and
+    /// any other <see cref="Parameter"/>) by delegating to the same
+    /// <see cref="Parameter.CanSupplyValue"/> logic Autofac uses for normal
+    /// constructor injection.
+    /// </summary>
+    /// <param name="serviceType">The type being mocked.</param>
+    /// <param name="parameters">The parameters supplied by the caller.</param>
+    /// <param name="context">The component context used to resolve values.</param>
+    /// <returns>
+    /// The constructor arguments in positional order, or an empty array if no
+    /// constructor can be fully satisfied by the supplied parameters.
+    /// </returns>
+    private static object?[] BuildConstructorArguments(Type serviceType, Parameter[] parameters, IComponentContext context)
+    {
+        // Include non-public constructors: abstract classes commonly expose a
+        // protected constructor, and Moq/Castle can use it.
+        var constructors = serviceType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        object?[]? bestMatch = null;
+
+        foreach (var constructor in constructors)
+        {
+            var constructorParameters = constructor.GetParameters();
+
+            // Prefer the constructor with the most parameters that can be fully
+            // satisfied by the supplied values.
+            if (constructorParameters.Length > (bestMatch?.Length ?? 0) &&
+                TryBuildArguments(constructorParameters, parameters, context, out var arguments))
+            {
+                bestMatch = arguments;
+            }
+        }
+
+        return bestMatch ?? Array.Empty<object?>();
+    }
+
+    /// <summary>
+    /// Attempts to build the positional argument list for a single constructor
+    /// from the supplied parameters.
+    /// </summary>
+    /// <param name="constructorParameters">The constructor's parameters.</param>
+    /// <param name="parameters">The parameters supplied by the caller.</param>
+    /// <param name="context">The component context used to resolve values.</param>
+    /// <param name="arguments">The resolved positional arguments, if successful.</param>
+    /// <returns>
+    /// <see langword="true" /> if every constructor parameter could be supplied
+    /// a value; otherwise <see langword="false" />.
+    /// </returns>
+    private static bool TryBuildArguments(ParameterInfo[] constructorParameters, Parameter[] parameters, IComponentContext context, out object?[] arguments)
+    {
+        arguments = new object?[constructorParameters.Length];
+
+        for (var i = 0; i < constructorParameters.Length; i++)
+        {
+            if (!TrySupplyValue(constructorParameters[i], parameters, context, out arguments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Finds the first supplied parameter able to provide a value for the given
+    /// constructor parameter.
+    /// </summary>
+    /// <param name="constructorParameter">The constructor parameter to satisfy.</param>
+    /// <param name="parameters">The parameters supplied by the caller.</param>
+    /// <param name="context">The component context used to resolve values.</param>
+    /// <param name="value">The resolved value, if one was supplied.</param>
+    /// <returns>
+    /// <see langword="true" /> if a value was supplied; otherwise <see langword="false" />.
+    /// </returns>
+    private static bool TrySupplyValue(ParameterInfo constructorParameter, Parameter[] parameters, IComponentContext context, out object? value)
+    {
+        foreach (var parameter in parameters)
+        {
+            if (parameter.CanSupplyValue(constructorParameter, context, out var valueProvider))
+            {
+                value = valueProvider();
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
     private bool ServiceManuallyCreated(TypedService typedService)
     {
         return _createdServiceTypes.Contains(typedService.ServiceType);
@@ -208,15 +308,38 @@ internal class MoqRegistrationHandler : IRegistrationSource
     /// </summary>
     /// <param name="context">The component context.</param>
     /// <param name="typedService">The typed service.</param>
+    /// <param name="parameters">
+    /// The parameters supplied when the mock was requested. When present, they
+    /// are forwarded as constructor arguments to the mocked type (issue #42).
+    /// </param>
     /// <returns>
     /// The mock object from the repository.
     /// </returns>
-    private object CreateMock(IComponentContext context, TypedService typedService)
+    private object CreateMock(IComponentContext context, TypedService typedService, IEnumerable<Parameter> parameters)
     {
         try
         {
-            var specificCreateMethod = _createMethod.MakeGenericMethod(typedService.ServiceType);
-            var mock = (Mock)specificCreateMethod.Invoke(context.Resolve<MockRepository>(), null)!;
+            var repository = context.Resolve<MockRepository>();
+            var parameterArray = parameters as Parameter[] ?? parameters.ToArray();
+            var constructorArguments = parameterArray.Length == 0
+                ? Array.Empty<object?>()
+                : BuildConstructorArguments(typedService.ServiceType, parameterArray, context);
+
+            Mock mock;
+            if (constructorArguments.Length == 0)
+            {
+                // No usable constructor arguments: use the parameterless Create<T>()
+                // so behavior is identical to a mock requested without parameters.
+                var specificCreateMethod = _createMethod.MakeGenericMethod(typedService.ServiceType);
+                mock = (Mock)specificCreateMethod.Invoke(repository, null)!;
+            }
+            else
+            {
+                // Forward the constructor arguments to Moq's Create<T>(object[]).
+                var specificCreateMethod = _createWithArgsMethod.MakeGenericMethod(typedService.ServiceType);
+                mock = (Mock)specificCreateMethod.Invoke(repository, new object[] { constructorArguments })!;
+            }
+
             return mock.Object;
         }
         catch (TargetInvocationException ex)

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -399,6 +399,37 @@ public class AutoMockFixture
     }
 
     [Fact]
+    public void MockWithParameterSelectsTheConstructorTheParametersSatisfy()
+    {
+        // Issue #42 - when the type has multiple constructors, the supplied
+        // parameters should select the constructor they can fully satisfy. The
+        // string parameter cannot satisfy the (int) constructor, so the (string)
+        // constructor is chosen.
+        using (var mock = AutoMock.GetLoose())
+        {
+            var abstractMock = mock.Mock<AbstractTypeWithMultipleConstructors>(new TypedParameter(typeof(string), "hello"));
+
+            Assert.Equal("hello", abstractMock.Object.Text);
+            Assert.Equal(0, abstractMock.Object.Number);
+        }
+    }
+
+    [Fact]
+    public void MockWithUnsatisfiableParameterFallsBackToParameterlessCreation()
+    {
+        // Issue #42 - when the supplied parameters don't satisfy any constructor
+        // with arguments, mock creation falls back to the parameterless path. An
+        // interface has no constructor to satisfy, so the parameter is ignored.
+        using (var mock = AutoMock.GetLoose())
+        {
+            var interfaceMock = mock.Mock<ITestInterfaceOne>(new TypedParameter(typeof(int), 5));
+            interfaceMock.Setup(x => x.DoWork()).Returns(7);
+
+            Assert.Equal(7, interfaceMock.Object.DoWork());
+        }
+    }
+
+    [Fact]
     public void MockedClassWithConstructorThrows()
     {
         using (var mock = AutoMock.GetLoose())
@@ -491,6 +522,31 @@ public class AutoMockFixture
         }
 
         public int Param
+        {
+            get;
+        }
+
+        public abstract int DoThing();
+    }
+
+    public abstract class AbstractTypeWithMultipleConstructors
+    {
+        protected AbstractTypeWithMultipleConstructors(int number)
+        {
+            Number = number;
+        }
+
+        protected AbstractTypeWithMultipleConstructors(string text)
+        {
+            Text = text;
+        }
+
+        public int Number
+        {
+            get;
+        }
+
+        public string? Text
         {
             get;
         }

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -360,6 +360,45 @@ public class AutoMockFixture
     }
 
     [Fact]
+    public void MockWithTypedParameterUsesConstructorWithArguments()
+    {
+        // Issue #42 - parameters passed to Mock<T> should be forwarded to the
+        // constructor of the mocked type.
+        using (var mock = AutoMock.GetLoose())
+        {
+            var abstractMock = mock.Mock<AbstractTypeWithParameter>(new TypedParameter(typeof(int), 8));
+            abstractMock.Setup(q => q.DoThing()).Returns(16);
+
+            Assert.Equal(8, abstractMock.Object.Param);
+            Assert.Equal(16, abstractMock.Object.DoThing());
+        }
+    }
+
+    [Fact]
+    public void MockWithNamedParameterUsesConstructorWithArguments()
+    {
+        // Issue #42 - NamedParameter should map to the matching constructor parameter.
+        using (var mock = AutoMock.GetLoose())
+        {
+            var abstractMock = mock.Mock<AbstractTypeWithParameter>(new NamedParameter("param", 42));
+
+            Assert.Equal(42, abstractMock.Object.Param);
+        }
+    }
+
+    [Fact]
+    public void MockWithPositionalParameterUsesConstructorWithArguments()
+    {
+        // Issue #42 - PositionalParameter should map to the constructor parameter by index.
+        using (var mock = AutoMock.GetLoose())
+        {
+            var abstractMock = mock.Mock<AbstractTypeWithParameter>(new PositionalParameter(0, 99));
+
+            Assert.Equal(99, abstractMock.Object.Param);
+        }
+    }
+
+    [Fact]
     public void MockedClassWithConstructorThrows()
     {
         using (var mock = AutoMock.GetLoose())
@@ -443,6 +482,21 @@ public class AutoMockFixture
     }
 
     public delegate int TestDelegate(int x);
+
+    public abstract class AbstractTypeWithParameter
+    {
+        protected AbstractTypeWithParameter(int param)
+        {
+            Param = param;
+        }
+
+        public int Param
+        {
+            get;
+        }
+
+        public abstract int DoThing();
+    }
 
     internal class ConsumesDisposable
     {


### PR DESCRIPTION
Fixes #42.

## Problem

Parameters passed to `Mock<T>(...)` were ignored. When mocking an abstract (or non-sealed) class whose only constructor takes arguments, Castle DynamicProxy couldn't find a parameterless constructor and the resolve failed with `Could not find a parameterless constructor`.

`MoqRegistrationHandler.CreateMock` always called the zero-argument `MockRepository.Create<T>()` and discarded the Autofac `Parameter[]` entirely.

## Fix

`CreateMock` now receives the resolve-time parameters and, when any are supplied, maps them onto the mocked type's best-matching constructor and forwards them to Moq's `Create<T>(object[])` overload.

- Mapping uses Autofac's own `Parameter.CanSupplyValue`, so `TypedParameter`, `NamedParameter`, and `PositionalParameter` all work the same way they do for normal constructor injection.
- Non-public constructors are considered (abstract classes commonly expose a `protected` constructor).
- Constructor selection picks the satisfiable constructor with the most parameters.
- When no parameters are supplied, behavior is identical to the previous parameterless `Create<T>()` path.

## Reviewer note

The "most parameters that can be satisfied" heuristic for constructor selection is a deliberate choice worth a look if a mocked type has multiple overlapping constructors.

## Tests

Added regression tests covering `TypedParameter`, `NamedParameter`, and `PositionalParameter` against an abstract type with a parameterized constructor. Full suite passes (51 tests).