### PR TITLE
Support mocking delegate types (#48)

### DIFF
--- a/src/Autofac.Extras.Moq/AutoMock.cs
+++ b/src/Autofac.Extras.Moq/AutoMock.cs
@@ -182,8 +182,12 @@ public class AutoMock : IDisposable
     public Mock<T> Mock<T>(params Parameter[] parameters)
         where T : class
     {
-        var obj = (IMocked<T>)Create<T>(true, parameters);
-        return obj.Mock;
+        // Mock.Get retrieves the Mock<T> from Moq's internal registry rather
+        // than casting the resolved object to IMocked<T>. This is important for
+        // delegate mocks (issue #48): the Object of a delegate mock is the
+        // delegate itself and does not implement IMocked<T>, so a direct cast
+        // would throw an InvalidCastException.
+        return global::Moq.Mock.Get(Create<T>(true, parameters));
     }
 
     /// <summary>

--- a/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
+++ b/test/Autofac.Extras.Moq.Test/AutoMockFixture.cs
@@ -346,6 +346,20 @@ public class AutoMockFixture
     }
 
     [Fact]
+    public void MockOfDelegateTypeSucceeds()
+    {
+        // Issue #48 - mocking a delegate type used to throw InvalidCastException
+        // because the delegate Object does not implement IMocked<T>.
+        using (var mock = AutoMock.GetLoose())
+        {
+            var delegateMock = mock.Mock<TestDelegate>();
+            delegateMock.Setup(x => x(It.IsAny<int>())).Returns(20);
+
+            Assert.Equal(20, delegateMock.Object.Invoke(5));
+        }
+    }
+
+    [Fact]
     public void MockedClassWithConstructorThrows()
     {
         using (var mock = AutoMock.GetLoose())
@@ -427,6 +441,8 @@ public class AutoMockFixture
         {
         }
     }
+
+    public delegate int TestDelegate(int x);
 
     internal class ConsumesDisposable
     {


### PR DESCRIPTION
Fixes #48.

## Problem

`AutoMock.Mock<T>()` cast the resolved object to `IMocked<T>`:

```csharp
var obj = (IMocked<T>)Create<T>(true, parameters);
return obj.Mock;
```

For interfaces and classes, Moq's proxy `.Object` implements `IMocked<T>`, so this works. But for a **delegate** mock, `.Object` is the delegate itself and does not implement `IMocked<T>`, so the cast threw:

```
Unable to cast object of type 'MyDelegate' to type 'Moq.IMocked`1[MyDelegate]'.
```

## Fix

Use `Moq.Mock.Get(...)` instead of the cast. `Mock.Get` retrieves the `Mock<T>` from Moq's internal registry rather than relying on the resolved object implementing `IMocked<T>`, so it works for delegate mocks as well as interfaces and classes.

## Tests

Added a regression test that mocks a delegate type, sets it up, and invokes it. Full suite passes (49 tests).