### PR TITLE
Document mixing real framework services with AutoMock (#49)

### DIFF
--- a/src/Autofac.Extras.Moq/AutoMock.cs
+++ b/src/Autofac.Extras.Moq/AutoMock.cs
@@ -9,6 +9,23 @@ namespace Autofac.Extras.Moq;
 /// <summary>
 /// Wrapper around <see cref="Autofac"/> and <see cref="Moq"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Adding real framework services (for example, Entity Framework Core or
+/// <c>Microsoft.Extensions.Logging</c>) into the <see cref="AutoMock"/> container can
+/// produce unexpected behavior. <see cref="AutoMock"/> automatically supplies a mock
+/// for any service it can't otherwise resolve, including the individual elements of an
+/// otherwise-empty collection dependency (such as <c>IEnumerable&lt;ILoggerProvider&gt;</c>).
+/// A loosely-mocked element returns <see langword="null" /> from members that aren't
+/// explicitly set up, which can cause the consuming framework to throw - for example a
+/// <see cref="NullReferenceException"/> deep inside the framework's own code.
+/// </para>
+/// <para>
+/// If you need real framework services in your test, register concrete implementations for
+/// the services that framework consumes (or avoid mixing real framework wiring into the
+/// auto-mocking container) so that <see cref="AutoMock"/> does not fill those slots with mocks.
+/// </para>
+/// </remarks>
 public class AutoMock : IDisposable
 {
     private readonly HashSet<Type> _createdServiceTypes = new();

--- a/src/Autofac.Extras.Moq/AutoMock.cs
+++ b/src/Autofac.Extras.Moq/AutoMock.cs
@@ -12,18 +12,21 @@ namespace Autofac.Extras.Moq;
 /// <remarks>
 /// <para>
 /// Adding real framework services (for example, Entity Framework Core or
-/// <c>Microsoft.Extensions.Logging</c>) into the <see cref="AutoMock"/> container can
-/// produce unexpected behavior. <see cref="AutoMock"/> automatically supplies a mock
-/// for any service it can't otherwise resolve, including the individual elements of an
-/// otherwise-empty collection dependency (such as <c>IEnumerable&lt;ILoggerProvider&gt;</c>).
-/// A loosely-mocked element returns <see langword="null" /> from members that aren't
-/// explicitly set up, which can cause the consuming framework to throw - for example a
-/// <see cref="NullReferenceException"/> deep inside the framework's own code.
+/// <c>Microsoft.Extensions.Logging</c>) into the <see cref="AutoMock"/>
+/// container can produce unexpected behavior. <see cref="AutoMock"/>
+/// automatically supplies a mock for any service it can't otherwise resolve,
+/// including the individual elements of an otherwise-empty collection
+/// dependency (such as <c>IEnumerable&lt;ILoggerProvider&gt;</c>). A
+/// loosely-mocked element returns <see langword="null" /> from members that
+/// aren't explicitly set up, which can cause the consuming framework to throw -
+/// for example a <see cref="NullReferenceException"/> deep inside the
+/// framework's own code.
 /// </para>
 /// <para>
-/// If you need real framework services in your test, register concrete implementations for
-/// the services that framework consumes (or avoid mixing real framework wiring into the
-/// auto-mocking container) so that <see cref="AutoMock"/> does not fill those slots with mocks.
+/// If you need real framework services in your test, register concrete
+/// implementations for the services that framework consumes (or avoid mixing
+/// real framework wiring into the auto-mocking container) so that
+/// <see cref="AutoMock"/> does not fill those slots with mocks.
 /// </para>
 /// </remarks>
 public class AutoMock : IDisposable


### PR DESCRIPTION
Addresses #49.

## Background

In #49, constructing an EF Core `DbContext` inside an `AutoMock` container that also had logging wired up threw a `NullReferenceException` deep inside `Microsoft.Extensions.Logging`.

## Root cause (not a defect to "fix" in code)

`AutoMock` supplies a mock for any service it can't otherwise resolve, **including the individual elements of an otherwise-empty collection dependency**. So `IEnumerable<ILoggerProvider>` — which is legitimately *empty* in normal DI — instead gets a single mock element injected. That loose mock's `CreateLogger` returns `null`, and `LoggerFactory` then dereferences the null.

This single-element injection is intentional, long-standing behavior (it's what lets you test collection-style dependencies), and it's shared identically with the FakeItEasy integration. It is also non-recursive — it stops at the mock boundary and does not cascade into nested collections. So rather than change that behavior (a breaking change with real downsides), this documents the interaction and the workaround.

The test-ordering quirk in the original report is EF Core's static service-provider cache masking the problem when a "good" path runs first; it's outside our control.

## Change

Adds `<remarks>` to the `AutoMock` class describing that adding real framework services into the container can yield null-returning mocks in framework-consumed collections, and how to avoid it (register the concrete services the framework consumes).

## Related

Companion documentation PR with the detailed guidance: autofac/Documentation#185