### PR TITLE
Update dependencies (Autofac 9.3.1)

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <!-- Increment the overall semantic version here. -->
-    <Version>8.0.0</Version>
+    <Version>8.0.1</Version>
     <SolutionName>Autofac.Extras.Moq</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
+++ b/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
@@ -54,12 +54,12 @@
     <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.3.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
+++ b/src/Autofac.Extras.Moq/Autofac.Extras.Moq.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Autofac.Extras.Moq.Test/Autofac.Extras.Moq.Test.csproj
+++ b/test/Autofac.Extras.Moq.Test/Autofac.Extras.Moq.Test.csproj
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Autofac (src): 9.3.0 -> 9.3.1
- SonarAnalyzer.CSharp (src + test, analyzer/private): 10.27.0.140913 -> 10.28.0.143324
- Package version bump: 8.0.0 -> 8.0.1

This is a pure Autofac 9.3.1 patch update. No other shipping/runtime dependencies were changed.

## Test plan

- [ ] CI build passes (compile, test, package)
- [ ] No new warnings or errors introduced